### PR TITLE
Fixes module's source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Usage Example:
 
 ```hcl
 module "tf_state_bucket" {
-  source = "iits-consulting/state_bucket/opentelekomcloud"
+  source = "iits-consulting/state-bucket/opentelekomcloud"
 
   tf_state_bucket_name = "${var.context}-${var.stage}-kubernetes-tfstate"
   providers = {


### PR DESCRIPTION
Executing terraform init with the original source path (containing an underscore) leads to the following error message on terraform init:  

```powershell
λ terraform init
Initializing the backend...
Initializing modules...
Downloading registry.terraform.io/iits-consulting/project-factory/opentelekomcloud 7.4.1 for project-factory...
- project-factory in .terraform\modules\project-factory
╷
│ Error: Module not found
│ 
│   on main.tf line 25:
│   25: module "tf_state_backend" {
│ 
│ Module "tf_state_backend" (from main.tf:25) cannot be found in the module registry at registry.terraform.io.
╵
```