### PR TITLE
fix: remove usage of lockfile for s3 state buckets due to missing fea…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,6 @@ output "terraform_state_backend_config" {
       skip_credentials_validation = true
       skip_requesting_account_id  = true
       skip_metadata_api_check     = true
-      use_lockfile                = true
     }
   EOT
 }


### PR DESCRIPTION
…ture on OTC

OTC is currently lacking headers in their OBS implementation, which are needed to use the use_lockfile in the backend. Due to this fact, we're removing this setting from the default output sample.

Ticket: OTC-103